### PR TITLE
feat(components): 更新用户名修改规则的 tooltip 文本

### DIFF
--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -1456,13 +1456,13 @@ const [moYuData, setMoYuData] = useState<MoYuTimeType>({
           <Form.Item
             name="userName"
             label="用户名"
-            tooltip={'用户名每月只能修改一次，且消耗100积分'}
+            tooltip={'新用户免费修改一次用户名，后面每月只能修改一次，且消耗100积分'}
             rules={[
               {required: true, message: '请输入用户名！'},
               {max: 10, message: '用户名不能超过10个字符！'},
             ]}
           >
-            <Input maxLength={10} showCount placeholder="请输入用户名"/>
+            <Input maxLength={10} showCount placeholder="请输入用户名" />
           </Form.Item>
 
           <Form.Item


### PR DESCRIPTION
- 在 AvatarDropdown 组件中，更新了用户名修改规则的 tooltip 文本
- 新文本说明了新用户可免费修改一次用户名，后续每月只能修改一次并消耗 100 积分
- 同时修复了 Input 组件的 placeholder 属性，添加了结尾的斜杠