### PR TITLE
feat(消息内容): 添加图片显示设置功能

### DIFF
--- a/src/components/MessageContent/index.less
+++ b/src/components/MessageContent/index.less
@@ -406,3 +406,42 @@
     }
   }
 }
+
+
+.imageContainer {
+  position: relative;
+  display: inline-block;
+}
+
+
+.imageContainer:hover .favoriteButton {
+  opacity: 1;
+}
+.imageText {
+  padding: 8px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #666;
+  &:hover {
+    background: #e8e8e8;
+  }
+}
+.imageControls {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  right: 4px;
+  display: flex;
+  justify-content: space-between;
+  opacity: 0;
+  transition: opacity 0.3s;
+  background: rgba(255, 255, 255, 0.5);
+  padding: 4px;
+  border-radius: 2px;
+}
+.hideButton {
+  color: #ff4d4f !important;
+  background-color: #cfcfcf;
+}
+

--- a/src/components/MessageContent/index.tsx
+++ b/src/components/MessageContent/index.tsx
@@ -212,8 +212,36 @@ const MessageContent: React.FC<MessageContentProps> = ({ content, onImageLoad })
     document.body.removeChild(link);
   };
 
-  // 渲染图片
+  // 在组件顶部添加状态
+  const [imageDisplayMode, setImageDisplayMode] = useState('show');
+  const [shownImages, setShownImages] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const siteConfig = localStorage.getItem('siteConfig');
+    if (siteConfig) {
+      const { imageDisplayMode: mode } = JSON.parse(siteConfig);
+      setImageDisplayMode(mode || 'show');
+    }
+  }, []);
+
+  // 修改renderImage函数
   const renderImage = (url: string, key: string) => {
+    const isHidden = imageDisplayMode === 'hide' && !shownImages.has(url);
+
+    if (isHidden) {
+      return (
+        <div 
+          key={key} 
+          className={styles.imageText}
+          onClick={() => {
+            setShownImages(prev => new Set([...prev, url]));
+          }}
+        >
+          图片（点击显示）
+        </div>
+      );
+    }
+
     return (
       <div key={key} className={styles.imageContainer}>
         <Image
@@ -227,6 +255,24 @@ const MessageContent: React.FC<MessageContentProps> = ({ content, onImageLoad })
             onImageLoad?.();
           }}
         />
+        <div>
+          {imageDisplayMode === 'hide' && (
+            <Button
+              type="text"
+              size="small"
+              className={styles.hideButton}
+              onClick={() => {
+                setShownImages(prev => {
+                  const newSet = new Set(prev);
+                  newSet.delete(url);
+                  return newSet;
+                });
+              }}
+            >
+              隐藏
+            </Button>
+          )}
+        </div>
         <Button
           type="text"
           size="small"

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -2026,6 +2026,19 @@ const [moYuData, setMoYuData] = useState<MoYuTimeType>({
             />
           </Form.Item>
 
+          <Form.Item
+            label="图片显示设置"
+            name="imageDisplayMode"
+            help="设置聊天记录中图片的显示方式"
+          >
+            <Select
+              options={[
+                { label: '显示所有图片', value: 'show' },
+                { label: '隐藏所有图片', value: 'hide' }
+              ]}
+            />
+          </Form.Item>
+
           <Form.Item>
             <Space>
               <Button type="primary" htmlType="submit">


### PR DESCRIPTION
新增图片显示设置选项，支持显示或隐藏聊天记录中的图片。当设置为隐藏时，图片将显示为可点击的占位文本，点击后才会显示原图。同时添加隐藏按钮，允许用户手动隐藏已显示的图片。