### PR TITLE
fix(AvatarDropdown): 移除称号选择器的allowClear属性

### DIFF
--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -1631,7 +1631,6 @@ const [moYuData, setMoYuData] = useState<MoYuTimeType>({
               <Select
                 placeholder="请选择称号"
                 onChange={handleSetTitle}
-                allowClear
                 value={currentUser?.titleId}
               >
                 {availableTitles.map((title) => (


### PR DESCRIPTION
防止尝试移除称号时触发handleSetTitle方法引发接口调用报错
![image](https://github.com/user-attachments/assets/3d64e280-f563-4414-9b12-7107ff16ede5)
