### PR TITLE
ref(Gameactor): 优化新英雄信息展示样式

### DIFF
--- a/src/pages/Game/GuessHero/index.tsx
+++ b/src/pages/Game/GuessHero/index.tsx
@@ -349,18 +349,15 @@ const GuessHero: React.FC = () => {
               <img
                 src={`https://game.gtimg.cn/images/yxzj/img201606/heroimg/${newHero.ename}/${newHero.ename}.jpg`}
                 alt="最新英雄"
-                style={{width: 40, height: 40, borderRadius: 4}}
+                style={{width: 80, height: 80, borderRadius: 4}}
               />
               <div>
                 <div>名称：<strong>{newHero.cname}</strong></div>
-                <div>上线时间：<strong>{newHero.releaseDate}</strong></div>
-              </div>
-              <div>
                 <div>定位：<strong>{typeMap[newHero.primaryType as keyof typeof typeMap] || newHero.primaryType}</strong>
                 </div>
                 <div>种族：<strong>{newHero.race || '无'}</strong></div>
+                <div>首发：<strong>{newHero.releaseDate}</strong></div>
               </div>
-
             </Space>
           ) : (
             <span style={{color: '#888'}}>暂无最新英雄信息</span>


### PR DESCRIPTION
- 增大新英雄图片尺寸，从40x40 改为 80x80
- 调整新英雄信息布局，使内容更加紧凑 -将"上线时间"改为"首发"，以更准确地描述英雄发布时间