### PR TITLE
feat(Game): 在猜英雄排行榜中添加当前用户排名信息

### DIFF
--- a/src/services/backend/heroController.ts
+++ b/src/services/backend/heroController.ts
@@ -72,6 +72,14 @@ export async function recordGuessSuccessUsingPost(
   });
 }
 
+/** getCurrentUserGuessData GET /api/hero/guess/user */
+export async function getCurrentUserGuessDataUsingGet(options?: { [key: string]: any }) {
+  return request<API.BaseResponseHeroRankingVO_>('/api/hero/guess/user', {
+    method: 'GET',
+    ...(options || {}),
+  });
+}
+
 /** listSimpleHero GET /api/hero/list/simple */
 export async function listSimpleHeroUsingGet(options?: { [key: string]: any }) {
   return request<API.BaseResponseListSimpleHeroVO_>('/api/hero/list/simple', {

--- a/src/services/backend/typings.d.ts
+++ b/src/services/backend/typings.d.ts
@@ -63,6 +63,12 @@ declare namespace API {
     message?: string;
   };
 
+  type BaseResponseHeroRankingVO_ = {
+    code?: number;
+    data?: HeroRankingVO;
+    message?: string;
+  };
+
   type BaseResponseHeroVO_ = {
     code?: number;
     data?: HeroVO;


### PR DESCRIPTION
- 新增 getCurrentUserGuessDataUsingGet接口获取当前用户猜英雄数据
- 在排行榜中添加当前用户排名信息展示
- 优化排行榜渲染逻辑，支持加载中和未上榜状态显示