### PR TITLE
feat(landlords): 房间超时跳走 + 邀请 + 聊天限制 + 玩家头像

### DIFF
--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -2120,6 +2120,9 @@ const ChatRoom: React.FC = () => {
           message.error('加入房间失败，请稍后再试');
         }
         break;
+      case 'landlords':
+        history.push(`/game/landlords/${roomId}`);
+        break;
       default:
         break;
     }
@@ -2424,6 +2427,9 @@ const ChatRoom: React.FC = () => {
           break;
         case 'draw':
           game = '你画我猜';
+          break;
+        case 'landlords':
+          game = '斗地主';
           break;
       }
       return (

--- a/src/pages/Game/Landlords/LandlordsRoom.tsx
+++ b/src/pages/Game/Landlords/LandlordsRoom.tsx
@@ -16,10 +16,11 @@
  *
  * 业务逻辑全部由 useGameState Hook 提供。
  */
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { Button, Tag, message as antdMessage, Alert } from 'antd';
 import { ArrowLeft } from 'lucide-react';
-import { history } from '@umijs/max';
+import { history, useModel } from '@umijs/max';
+import { wsService } from '@/services/websocket';
 import PlayerInfo from './components/PlayerInfo';
 import LandlordCards from './components/LandlordCards';
 import HandCards from './components/HandCards';
@@ -33,6 +34,14 @@ import { isWaitingPhase, isPlayingPhase, isRobbingPhase, canPlayPhase } from './
 
 const LandlordsRoom: React.FC = () => {
   const roomId = window.location.pathname.split('/').pop() || '';
+  const { initialState } = useModel('@@initialState');
+  const currentUserInfo = initialState?.currentUser;
+
+  // 邀请冷却状态
+  const [inviteCooldown, setInviteCooldown] = useState<number>(0);
+  const inviteCooldownRef = useRef<NodeJS.Timeout | null>(null);
+
+  const userId = currentUserInfo?.id;
 
   const {
     gameState,
@@ -119,12 +128,109 @@ const LandlordsRoom: React.FC = () => {
     history.push('/game/landlords');
   }, [leaveRoom, roomId]);
 
-  // 临时离开
+  // 房间超时解散（后端定时任务触发：凑不齐人 / 全员离线）
+  // 收到广播后立即弹提示并跳回房间列表，避免用户卡在房间页
   useEffect(() => {
-    if (tempLeaveInfo) {
-    }
-  }, [tempLeaveInfo]);
+    if (!userId || !roomId) return undefined;
 
+    const handler = (data: any) => {
+      const payload = data?.data ?? data;
+      if (payload?.roomId && String(payload.roomId) === String(roomId)) {
+        const reason = payload.reason || '房间已解散';
+        antdMessage.warning(reason);
+        // 与 handleLeave 保持一致：标记本地已离开 → 调 leaveRoom → 跳列表
+        localStorage.setItem(
+          'landlords_left_room',
+          JSON.stringify({ roomId, timestamp: Date.now(), force: true }),
+        );
+        leaveRoom();
+        history.push('/game/landlords');
+      }
+    };
+
+    wsService.addMessageHandler('gameRoomClosed', handler);
+    return () => {
+      wsService.removeMessageHandler('gameRoomClosed', handler);
+    };
+  }, [userId, roomId, leaveRoom]);
+
+  // 发送邀请到鱼窝
+  const handleSendInvite = useCallback(() => {
+    if (!currentUserInfo?.id) {
+      antdMessage.error('请先登录！');
+      return;
+    }
+
+    if (inviteCooldown > 0) {
+      antdMessage.warning(`请等待 ${inviteCooldown} 秒后再发送邀请`);
+      return;
+    }
+
+    if (!roomId) {
+      antdMessage.error('房间不存在，无法发送邀请');
+      return;
+    }
+
+    // 创建邀请消息
+    const inviteMessage = `[invite/landlords]${roomId}[/invite]`;
+
+    // 使用全局 WebSocket 服务发送消息
+    wsService.send({
+      type: 2,
+      userId: -1,
+      data: {
+        type: 'chat',
+        content: {
+          message: {
+            id: `${Date.now()}`,
+            content: inviteMessage,
+            sender: {
+              id: String(currentUserInfo.id),
+              name: currentUserInfo.userName || '游客',
+              avatar: currentUserInfo.userAvatar || 'https://api.dicebear.com/7.x/avataaars/svg?seed=visitor',
+              level: currentUserInfo.level || 1,
+              isAdmin: currentUserInfo.userRole === 'admin',
+            },
+            timestamp: new Date(),
+          },
+        },
+      },
+    });
+
+    // 设置冷却时间
+    setInviteCooldown(60);
+
+    // 启动倒计时
+    if (inviteCooldownRef.current) {
+      clearInterval(inviteCooldownRef.current);
+    }
+
+    inviteCooldownRef.current = setInterval(() => {
+      setInviteCooldown((prev) => {
+        if (prev <= 1) {
+          if (inviteCooldownRef.current) {
+            clearInterval(inviteCooldownRef.current);
+            inviteCooldownRef.current = null;
+          }
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    antdMessage.success('邀请已发送到聊天室');
+  }, [currentUserInfo, roomId, inviteCooldown]);
+
+  // 清理冷却计时器
+  useEffect(() => {
+    return () => {
+      if (inviteCooldownRef.current) {
+        clearInterval(inviteCooldownRef.current);
+      }
+    };
+  }, []);
+
+  // 临时离开（UI 由下方 tempLeaveInfo 渲染，这里不再留空 effect）
   // 标准化玩家数据
   const formatPlayer = (player: PlayerState | null): PlayerState => ({
     userId: player?.userId || 0,
@@ -311,6 +417,8 @@ const LandlordsRoom: React.FC = () => {
           backgroundColor: '#ffffff',
           borderTop: '1px solid #e5e7eb',
           display: 'flex',
+          minHeight: 0,
+          overflow: 'hidden',
         }}
       >
         {/* 我的信息 18% */}
@@ -383,6 +491,11 @@ const LandlordsRoom: React.FC = () => {
               onCancelRobot={cancelRobot}
               onSetRobot={setRobot}
               onLeave={handleLeave}
+              roomId={roomId}
+              inviteCooldown={inviteCooldown}
+              onSendInvite={handleSendInvite}
+              playerCount={gameState.players?.length || 0}
+              maxPlayers={3}
             />
           </div>
 
@@ -426,13 +539,14 @@ const LandlordsRoom: React.FC = () => {
             flexDirection: 'column',
             padding: 12,
             minHeight: 0,
+            overflow: 'hidden',
             borderLeft: '1px solid #e5e7eb',
           }}
         >
           <ChatSidebar
             messages={chatMessages}
             onSend={sendChat}
-            currentUserId={currentUser?.userId}
+            currentUserId={currentUserInfo?.id ?? currentUser?.userId}
           />
         </div>
       </div>

--- a/src/pages/Game/Landlords/components/ActionBar.tsx
+++ b/src/pages/Game/Landlords/components/ActionBar.tsx
@@ -45,6 +45,13 @@ export interface ActionBarProps {
   // 等待提示
   waitForName?: string;
   waitForAction?: 'play' | 'rob';
+
+  // 邀请
+  roomId?: string;
+  inviteCooldown?: number;
+  onSendInvite?: () => void;
+  playerCount?: number;
+  maxPlayers?: number;
 }
 
 const ActionBar: React.FC<ActionBarProps> = ({
@@ -71,11 +78,18 @@ const ActionBar: React.FC<ActionBarProps> = ({
   onLeave,
   waitForName,
   waitForAction = 'play',
+  roomId,
+  inviteCooldown = 0,
+  onSendInvite,
+  playerCount = 0,
+  maxPlayers = 3,
 }) => {
   // 等待阶段
   if (isWaitingPhase(phase)) {
+    // 房间满人时所有人都不能再发送邀请
+    const isRoomFull = playerCount >= maxPlayers;
     return (
-      <Space style={{ width: '100%', justifyContent: 'center' }}>
+      <Space style={{ width: '100%', justifyContent: 'center' }} size="middle">
         <Button onClick={onReady} type={isReady ? 'default' : 'primary'}>
           {isReady ? '取消准备' : '准备'}
         </Button>
@@ -87,6 +101,15 @@ const ActionBar: React.FC<ActionBarProps> = ({
             style={{ backgroundColor: '#16a34a' }}
           >
             开始游戏
+          </Button>
+        )}
+        {roomId && onSendInvite && !isRoomFull && (
+          <Button
+            onClick={onSendInvite}
+            disabled={inviteCooldown > 0}
+            style={{ backgroundColor: '#52c41a', borderColor: '#52c41a' }}
+          >
+            {inviteCooldown > 0 ? `邀请中 (${inviteCooldown}s)` : '邀请好友'}
           </Button>
         )}
         <Button danger onClick={onLeave}>

--- a/src/pages/Game/Landlords/components/ChatSidebar.tsx
+++ b/src/pages/Game/Landlords/components/ChatSidebar.tsx
@@ -1,9 +1,11 @@
 /**
  * 内嵌聊天侧栏 - 直接显示在房间侧栏内（与 ChatPanel 浮窗模式不同）
+ *
+ * 斗地主房间内只允许发送预设的快捷短语，禁止自由输入，避免无关聊天打扰游戏
  */
 import React, { useState, useRef, useEffect } from 'react';
-import { Input } from 'antd';
-import { Send } from 'lucide-react';
+import { Button, Dropdown } from 'antd';
+import { DownOutlined, SmileOutlined } from '@ant-design/icons';
 import { ChatMessage } from '../types';
 
 export interface ChatSidebarProps {
@@ -13,13 +15,36 @@ export interface ChatSidebarProps {
   title?: string;
 }
 
+// 斗地主内置快捷短语
+const QUICK_PHRASES = [
+  '快点啊，我等到花儿都谢了！',
+  '牌不错，心情美美哒~',
+  '不好意思，我先走了 :)',
+  '再来一局吧！',
+  '别急，让我再想想。',
+  '别催了，我正在算牌。',
+  '打得不错，佩服佩服！',
+  '哇，这牌运也太好了吧！',
+  '不行，我得压你一手。',
+  '你这牌打得太好了，认输。',
+  '你这牌打得也太臭了吧！',
+  '哈哈，我终于赢了！',
+  '唉，又输了。',
+  '地主就是不一样啊！',
+  '农民也不容易啊！',
+  '炸弹！炸到你不要不要的~',
+  '顺子！我出顺子！',
+  '王炸！哈哈哈哈！',
+  '这局算你走运！',
+  '下局我一定赢回来！',
+];
+
 const ChatSidebar: React.FC<ChatSidebarProps> = ({
   messages,
   onSend,
   currentUserId,
   title = '聊天',
 }) => {
-  const [inputValue, setInputValue] = useState('');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // 新消息滚到底部
@@ -27,15 +52,32 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const handleSend = () => {
-    const v = inputValue.trim();
-    if (!v) return;
-    onSend(v);
-    setInputValue('');
+  // 点击预设短语即发送
+  const handlePickPhrase = (phrase: string) => {
+    onSend(phrase);
+  };
+
+  // 构建下拉菜单项
+  const phraseMenu = {
+    items: QUICK_PHRASES.map((phrase, idx) => ({
+      key: `phrase-${idx}`,
+      label: phrase,
+      onClick: () => handlePickPhrase(phrase),
+    })),
+    style: { maxHeight: 280, overflowY: 'auto' as const },
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        height: '100%',
+        overflow: 'hidden',
+      }}
+    >
       <div
         style={{
           fontSize: 14,
@@ -55,7 +97,7 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
           borderRadius: 6,
           padding: 8,
           fontSize: 12,
-          overflow: 'auto',
+          overflowY: 'auto',
           minHeight: 0,
         }}
       >
@@ -65,7 +107,10 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
           </div>
         ) : (
           messages.map((msg) => {
-            const isMe = currentUserId != null && String(msg.userId) === String(currentUserId);
+            // 优先用消息自带标记，避免 userId 异步未就绪时被误判
+            const isMe =
+              msg.isMe ??
+              (currentUserId != null && String(msg.userId) === String(currentUserId));
             return (
               <div
                 key={msg.id}
@@ -74,11 +119,23 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
                   textAlign: isMe ? 'right' : 'left',
                 }}
               >
-                <span style={{ color: '#6b7280', fontWeight: 500 }}>
-                  {msg.userName}
-                  {isMe && ' (我)'}:
-                </span>{' '}
-                <span style={{ color: '#1f2937' }}>{msg.content}</span>
+                {isMe ? (
+                  <>
+                    <span style={{ color: '#1f2937' }}>{msg.content}</span>
+                    {msg.userName ? '：' : ''}
+                    <span style={{ color: '#6b7280', fontWeight: 500 }}>
+                      {msg.userName}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span style={{ color: '#6b7280', fontWeight: 500 }}>
+                      {msg.userName}
+                    </span>
+                    {msg.userName ? '：' : ''}
+                    <span style={{ color: '#1f2937' }}>{msg.content}</span>
+                  </>
+                )}
               </div>
             );
           })
@@ -86,23 +143,31 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
         <div ref={messagesEndRef} />
       </div>
 
-      {/* 输入框 */}
-      <Input
-        placeholder="说点什么..."
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onPressEnter={handleSend}
-        style={{ marginTop: 8 }}
-        size="small"
-        suffix={
-          <Send
-            size={14}
-            style={{ cursor: 'pointer', color: inputValue.trim() ? '#16a34a' : '#9ca3af' }}
-            onClick={handleSend}
-          />
-        }
-        maxLength={200}
-      />
+      {/* 快捷短语区（替代自由输入） */}
+      <div
+        style={{
+          marginTop: 8,
+          flex: '0 0 auto',
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <Dropdown
+          menu={phraseMenu}
+          trigger={['click']}
+          placement="topRight"
+          overlayStyle={{ maxWidth: 240 }}
+        >
+          <Button
+            type="primary"
+            size="small"
+            icon={<SmileOutlined />}
+            style={{ width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            发送快捷短语 <DownOutlined />
+          </Button>
+        </Dropdown>
+      </div>
     </div>
   );
 };

--- a/src/pages/Game/Landlords/hooks/handlers/state.ts
+++ b/src/pages/Game/Landlords/hooks/handlers/state.ts
@@ -182,21 +182,27 @@ export const createGameStartHandler = (
 
 /**
  * 创建 GAME_CHAT 处理器
+ * @param setChatMessages 设置聊天消息列表
+ * @param getCurrentUserId 获取当前用户 ID 的函数（handler 可能晚于组件挂载创建，用 getter 保证最新值）
  */
 export const createGameChatHandler = (
   setChatMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>,
+  getCurrentUserId: () => string | number | null | undefined = () => null,
 ) => {
   return (payload: any) => {
     const data = payload?.data ?? payload;
-    console.debug('[landlords] chat', data);
+    const currentUserId = getCurrentUserId();
+    const isMe =
+      currentUserId != null && String(data.userId) === String(currentUserId);
     setChatMessages((prev) => [
       ...prev,
       {
         id: `${Date.now()}-${Math.random()}`,
         userId: data.userId,
-        userName: data.userName || '未知',
+        userName: data.userName || '',
         content: data.content || '',
         timestamp: Date.now(),
+        isMe,
       },
     ]);
   };

--- a/src/pages/Game/Landlords/hooks/useGameState.ts
+++ b/src/pages/Game/Landlords/hooks/useGameState.ts
@@ -109,7 +109,7 @@ export function useGameState(roomId: string | undefined) {
       setLoading,
     );
 
-    handleGameChatRef.current = createGameChatHandler(setChatMessages);
+    handleGameChatRef.current = createGameChatHandler(setChatMessages, () => userIdRef.current);
     handleGameReadyRef.current = createReadyHandler(setGameState);
     handleLeaveRoomRef.current = createLeaveRoomHandler(setTempLeaveInfo);
     handleTurnNotifyRef.current = createTurnNotifyHandler(
@@ -281,7 +281,7 @@ export function useGameState(roomId: string | undefined) {
     if (currentRoomId && currentUser) {
       sendGameMessage(MSG_TYPE.GAME_CHAT, {
         content,
-        userName: currentUser.userName || '玩家',
+        userName: currentUser.userName || '',
       });
     }
   };

--- a/src/pages/Game/Landlords/index.tsx
+++ b/src/pages/Game/Landlords/index.tsx
@@ -3,8 +3,8 @@
  */
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { PageContainer } from '@ant-design/pro-components';
-import { Card, Button, Tabs, List, Spin, message as antMessage, Empty, Tag, Space, Modal, Alert } from 'antd';
-import { Users, RefreshCw, Plus, Lock, Crown, PlayCircle, AlertCircle } from 'lucide-react';
+import { Card, Button, Tabs, List, Spin, message as antMessage, Empty, Tag, Space, Modal, Alert, Avatar, Tooltip } from 'antd';
+import { Users, RefreshCw, Plus, Lock, Crown, AlertCircle } from 'lucide-react';
 import { wsService } from '@/services/websocket';
 import { useModel, history } from '@umijs/max';
 import { RoomRestriction, RoomStateBackend } from './types';
@@ -14,6 +14,8 @@ const MSG_TYPE = {
   GAME_CREATE_ROOM: 'gameCreateRoom',
   GAME_ROOM_ADDED: 'gameRoomAdded',
   GAME_ROOM_REMOVED: 'gameRoomRemoved',
+  // 房间超时解散：如果当前用户被该房间限制，自动解除限制
+  GAME_ROOM_CLOSED: 'gameRoomClosed',
 };
 
 const codeToGameTypeName = (code: string) => {
@@ -110,6 +112,14 @@ const LandlordsIndex: React.FC = () => {
     }
   }, []);
 
+  // 房间超时解散：如果是自己受限的房间，立即解除限制（这样能直接进其它房间）
+  const handleGameRoomClosed = useCallback((payload: any) => {
+    const data = payload?.data ?? payload;
+    if (data?.roomId) {
+      setRestriction((prev) => (prev?.roomId === data.roomId ? null : prev));
+    }
+  }, []);
+
   const handleGameCreateRoom = useCallback((payload: any) => {
     const data = payload?.data ?? payload;
     if (data?.roomId) {
@@ -128,6 +138,7 @@ const LandlordsIndex: React.FC = () => {
       [MSG_TYPE.GAME_ROOM_LIST]: handleGameRoomList,
       [MSG_TYPE.GAME_ROOM_ADDED]: handleGameRoomAdded,
       [MSG_TYPE.GAME_ROOM_REMOVED]: handleGameRoomRemoved,
+      [MSG_TYPE.GAME_ROOM_CLOSED]: handleGameRoomClosed,
       [MSG_TYPE.GAME_CREATE_ROOM]: handleGameCreateRoom,
       error: handleError,
     };
@@ -172,6 +183,7 @@ const LandlordsIndex: React.FC = () => {
     handleGameRoomList,
     handleGameRoomAdded,
     handleGameRoomRemoved,
+    handleGameRoomClosed,
     handleGameCreateRoom,
     handleError,
   ]);
@@ -326,11 +338,15 @@ const LandlordsIndex: React.FC = () => {
         <Tabs
           activeKey={selectedGameType}
           onChange={(key) => {
+            // 癞子模式尚未实现，禁止切换
+            if (key === 'laizi') {
+              return;
+            }
             setSelectedGameType(key);
           }}
           items={[
             { key: 'classic', label: '经典模式' },
-            { key: 'laizi', label: '癞子模式' },
+            { key: 'laizi', label: '癞子模式（开发中）', disabled: true },
           ]}
         />
       </Card>
@@ -427,8 +443,8 @@ const LandlordsIndex: React.FC = () => {
                 const playerCount = item.playerCount || 0;
                 const maxPlayers = item.maxPlayers || 3;
                 const isFull = playerCount >= maxPlayers;
-                const isPlaying = item.state === RoomStateBackend.PLAYING || item.state === RoomStateBackend.ROBBING;
                 const isMyRoom = restriction?.roomId === item.roomId;
+                const players: any[] = Array.isArray(item.players) ? item.players : [];
 
                 return (
                   <List.Item>
@@ -448,9 +464,10 @@ const LandlordsIndex: React.FC = () => {
                           {isMyRoom && (
                             <Tag color="warning">你的房间</Tag>
                           )}
-                          {isPlaying && (
-                            <Tag color="error" icon={<PlayCircle />}>
-                              游戏中
+                          {/* 房间状态标签：等待/准备/发牌/叫地主/游戏中/结束 */}
+                          {item.state && item.state !== RoomStateBackend.CLOSED && (
+                            <Tag color={stateToTagColor(item.state)}>
+                              {stateToLabel(item.state)}
                             </Tag>
                           )}
                           {item.needPassword && (
@@ -464,11 +481,82 @@ const LandlordsIndex: React.FC = () => {
                           )}
                         </Space>
                       </div>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12, color: '#6b7280', fontSize: 14 }}>
-                        <Users size={14} />
-                        <span>
-                          {playerCount}/{maxPlayers} 人
+
+                      {/* 玩家头像区 */}
+                      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', flex: 1 }}>
+                          {Array.from({ length: maxPlayers }).map((_, idx) => {
+                            const p = players[idx];
+                            if (!p) {
+                              // 空位占位
+                              return (
+                                <div
+                                  key={`empty-${idx}`}
+                                  style={{
+                                    width: 36,
+                                    height: 36,
+                                    borderRadius: '50%',
+                                    border: '1.5px dashed #d1d5db',
+                                    backgroundColor: '#f9fafb',
+                                    marginLeft: idx === 0 ? 0 : -8,
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    color: '#9ca3af',
+                                    fontSize: 12,
+                                    zIndex: maxPlayers - idx,
+                                  }}
+                                >
+                                  ?
+                                </div>
+                              );
+                            }
+                            const online = p.online !== false;
+                            const tooltipText = `${p.userName || '玩家'}${online ? '' : '（离线）'}`;
+                            return (
+                              <Tooltip key={p.userId ?? idx} title={tooltipText}>
+                                <div
+                                  style={{
+                                    position: 'relative',
+                                    marginLeft: idx === 0 ? 0 : -8,
+                                    zIndex: maxPlayers - idx,
+                                  }}
+                                >
+                                  <Avatar
+                                    src={p.avatar}
+                                    size={36}
+                                    style={{
+                                      border: `2px solid ${online ? '#fff' : '#e5e7eb'}`,
+                                      filter: online ? 'none' : 'grayscale(100%) opacity(0.6)',
+                                      backgroundColor: '#e5e7eb',
+                                    }}
+                                  >
+                                    {(p.userName || '?').charAt(0)}
+                                  </Avatar>
+                                  {/* 在线小圆点 */}
+                                  <span
+                                    style={{
+                                      position: 'absolute',
+                                      right: 0,
+                                      bottom: 0,
+                                      width: 10,
+                                      height: 10,
+                                      borderRadius: '50%',
+                                      backgroundColor: online ? '#22c55e' : '#9ca3af',
+                                      border: '2px solid #fff',
+                                    }}
+                                  />
+                                </div>
+                              </Tooltip>
+                            );
+                          })}
+                        </div>
+                        <span style={{ color: '#6b7280', fontSize: 13 }}>
+                          {playerCount}/{maxPlayers}
                         </span>
+                      </div>
+
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12, color: '#6b7280', fontSize: 13 }}>
                         <span style={{ marginLeft: 'auto' }}>
                           {gameTypeToLabel(item.gameType)}
                         </span>

--- a/src/pages/Game/Landlords/types/state.ts
+++ b/src/pages/Game/Landlords/types/state.ts
@@ -71,6 +71,8 @@ export interface ChatMessage {
   userName: string;
   content: string;
   timestamp: number;
+  /** 是否是当前用户自己发的（前端在接收广播时根据当前 userId 标记，避免渲染时再比较出错） */
+  isMe?: boolean;
 }
 
 /**


### PR DESCRIPTION
- LandlordsRoom 监听 gameRoomClosed：收到广播立即弹提示并跳回房间列表
- ActionBar 新增「邀请好友」按钮 + 60s 冷却；房间满人时所有人隐藏按钮
- ChatSidebar 改造：斗地主房间禁用自由输入，改为预设 20 条快捷短语下拉菜单
  - 修复 overflowY 类型：使用 'auto' as const 匹配 antd MenuProps 字面量类型
- types/state.ChatMessage 新增 isMe 字段；handler 接收时根据当前 userId 标记
- useGameState 把 userId 改为 getter 注入 chat handler，避免闭包过期
- index 房间列表新增玩家头像堆叠展示（在线/离线/占位），并在收到 roomClosed 时自动解除受限状态
- index 癞子模式 Tab 标记为「开发中」并 disabled，防止误触发 LANDLORDS_LAIZI
- Chat/index 处理 landlords 邀请消息：跳转 /game/landlords/{roomId}